### PR TITLE
fix_updates_on_14Aug_push -- OfficeSupply creation errors — stop double-mutation and sanitize inputs

### DIFF
--- a/web/src/components/OfficeSupply/SupplyInventory/SupplyInventory.jsx
+++ b/web/src/components/OfficeSupply/SupplyInventory/SupplyInventory.jsx
@@ -119,21 +119,11 @@ const SupplyInventory = () => {
     }
   }
 
-  const handleFormSave = (formData) => {
-    if (editingSupply) {
-      updateSupply({ 
-        variables: { 
-          id: editingSupply.id, 
-          input: formData 
-        } 
-      })
-    } else {
-      createSupply({ 
-        variables: { 
-          input: formData 
-        } 
-      })
-    }
+  // Replace double-mutation: the form performs create/update itself and calls onSave afterwards.
+  const handleFormSave = () => {
+    refetch()
+    setEditingSupply(null)
+    setShowForm(false)
   }
 
   const filteredSupplies = data?.officeSupplies?.filter(supply => {


### PR DESCRIPTION
## Summary

Resolves GraphQL errors when creating supplies caused by invalid fields and missing categoryId.
Prevents the parent component from re-sending the created/updated entity as mutation input.
Changes

## web

### SupplyInventory.jsx

Removed double-mutation pattern: the parent no longer re-calls create/update on onSave.

### handleFormSave

Now only refetches data, clears editing state, and closes the form.

Prevents leaking fields like id, __typename, and category into CreateOfficeSupplyInput.

## api 

## officeSupplies.js

Validates required fields (categoryId, name, stockCount, unitPrice). 

Sanitizes inputs to only allow: name, description, stockCount, unitPrice, categoryId.

## Why

UI was re-sending the returned entity as input, adding disallowed fields and omitting required categoryId, causing GraphQL errors.

## How to Test

As ADMIN, open Inventory → Add New Supply.

Fill all fields including Category; save.

Creation should succeed with no GraphQL errors and item appears in the list.

Edit an existing supply; ensure update succeeds.

##Scope/Risk

No schema/migration changes.

Minimal impact; strictly limits inputs and fixes client flow.

