### PR TITLE
feat(attendance): show employee name in page title

### DIFF
--- a/web/src/pages/MeAttendancePage/MeAttendancePage.jsx
+++ b/web/src/pages/MeAttendancePage/MeAttendancePage.jsx
@@ -27,7 +27,11 @@ const MeAttendancePage = () => {
       <AppSidebar showQuickAccess={true} />
       <AppContentShell>
         <PageHeader
-          title="Attendance"
+          title={
+            currentUser.name
+              ? `Attendance — ${currentUser.name}`
+              : 'Attendance'
+          }
           description="View attendance history, exceptions, and exports."
         >
           <DropdownMenu>


### PR DESCRIPTION
Personalize the user attendance page header so the title reads "Attendance — <Name>" instead of just "Attendance". Falls back to plain "Attendance" when name is not set.